### PR TITLE
add setupProxy.js

### DIFF
--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -1,0 +1,9 @@
+const proxy = require('http-proxy-middleware');
+
+const proxyTarget  = {
+  target: 'http://127.0.0.1:8080',
+  // changeOrigin: true,
+}
+module.exports = function(app) {
+  app.use('/api', proxy(proxyTarget));
+};


### PR DESCRIPTION
`setupProxy.js` is required by the dev server and will only be run by the dev server, not in production.